### PR TITLE
Allow any extensions for testing files

### DIFF
--- a/spec/exercises.js
+++ b/spec/exercises.js
@@ -48,12 +48,12 @@ describe('Testing exercises', function () {
 		return wUtil.idFromName(exercise)
 	}).forEach(function (id, nr) {
 		var folder = path.join(process.cwd(), 'test', id)
-		  , allFiles = require('glob').sync('*.js', {
+		  , allFiles = require('glob').sync('*.*', {
 				cwd: folder
 			})
 
 		allFiles.filter(function (file) {
-			return /^(in)?valid_\d+.js$/.test(file)
+			return /^(in)?valid(-|_)?(\d*)?.\w+/.test(file)
 		}).forEach(function (file, fileNr) {
 			it('./' + path.relative(process.cwd(), path.join(folder, file)) + ' (' + nr + ':' + fileNr + ')	 ', function (done) {
 				exec.async(['select', id], function (err, stdout, stderr) {


### PR DESCRIPTION
Hey @workshopper/core and @workshopper/workshopper-adventure!

Here I let **workshopper-adventure-test** to match files with any extension (not only `.js`). That's needed for workshoppers like [`learnyoubash`](https://github.com/denysdovhan/learnyoubash) and [`how-to-markdown`](https://github.com/workshopper/how-to-markdown).

Also, it lets to match files without numbers, like:

```
valid.bash
invalid.md
valid01.js
invalid02.rb
```

and so on.